### PR TITLE
Bump dependencies, remove deprecated mineflayer-utils, and rearrange @ts-expect-error

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,16 +27,15 @@
   },
   "homepage": "https://github.com/TheDudeFromCI/mineflayer-tool#readme",
   "dependencies": {
-    "mineflayer": "^2.21.0",
-    "mineflayer-pathfinder": "^1.0.11",
-    "mineflayer-utils": "^0.1.4",
-    "prismarine-nbt": "^1.3.0"
+    "mineflayer": "^3.6.0",
+    "mineflayer-pathfinder": "^1.6.1",
+    "prismarine-nbt": "^1.5.0"
   },
   "devDependencies": {
     "@types/node": "^15.0.1",
     "require-self": "^0.2.3",
     "ts-standard": "^10.0.0",
-    "typescript": "^4.0.5"
+    "typescript": "^4.1.3"
   },
   "files": [
     "lib/**/*"

--- a/src/Inventory.ts
+++ b/src/Inventory.ts
@@ -3,7 +3,8 @@ import { Vec3 } from 'vec3'
 import { error, Callback } from './Tool'
 import { Item } from 'prismarine-item'
 import { goals, ComputedPath } from 'mineflayer-pathfinder'
-import { TemporarySubscriber, TaskQueue } from 'mineflayer-utils'
+import { TemporarySubscriber } from './TemporarySubscriber'
+import { TaskQueue } from './TaskQueue'
 
 /**
  * A standard tool filter that returns true for all tools and false

--- a/src/TaskQueue.ts
+++ b/src/TaskQueue.ts
@@ -1,0 +1,77 @@
+import type { Callback } from './Tool'
+export type Task = (cb: Callback) => void
+export type SyncTask = () => void
+
+/**
+ * A simple utility class for queuing up a series of async tasks to execute.
+ */
+export class TaskQueue {
+  private tasks: Task[] = []
+
+  /**
+   * If true, the task list will stop executing if one of the tasks throws an error.
+   */
+  readonly stopOnError: boolean = true
+
+  /**
+   * Adds a new async task to this queue. The provided callback should be executed when
+   * the async task is complete.
+   *
+   * @param task - The async task to add.
+   */
+  add (task: Task): void {
+    this.tasks.push(task)
+  }
+
+  /**
+   * Adds a synchronous task toi this queue.
+   *
+   * @param task - The sync task to add.
+   */
+  addSync (task: SyncTask): void {
+    this.add((cb) => {
+      try {
+        task()
+        cb()
+      } catch (err) {
+        cb(err)
+      }
+    })
+  }
+
+  /**
+   * Runs all tasks currently in this queue and empties the queue.
+   *
+   * @param cb - The optional callback to be executed when all tasks in this queue have
+   * finished executing.
+   */
+  runAll (cb?: Callback): void {
+    const taskList = this.tasks
+    this.tasks = []
+
+    let index = -1
+    const runNext: () => void = () => {
+      index++
+      if (index >= taskList.length) {
+        if (cb !== undefined) cb()
+        return
+      }
+
+      try {
+        taskList[index]((err) => {
+          if (err !== undefined) {
+            if (cb !== undefined) cb(err)
+
+            if (this.stopOnError) return
+          }
+
+          runNext()
+        })
+      } catch (err) {
+        if (cb !== undefined) cb(err)
+      }
+    }
+
+    runNext()
+  }
+}

--- a/src/TemporarySubscriber.ts
+++ b/src/TemporarySubscriber.ts
@@ -1,0 +1,34 @@
+import { Bot } from 'mineflayer'
+
+class Subscription {
+  constructor (readonly eventName: string, readonly callback: Function) {}
+}
+
+export class TemporarySubscriber {
+  private readonly subscriptions: Subscription[] = []
+
+  constructor (readonly bot: Bot) {}
+
+  /**
+   * Adds a new temporary event listener to the bot.
+   *
+   * @param event - The event to subscribe to.
+   * @param callback - The function to execute.
+   */
+  subscribeTo (event: string, callback: Function): void {
+    this.subscriptions.push(new Subscription(event, callback))
+
+    // @ts-expect-error
+    this.bot.on(event, callback)
+  }
+
+  /**
+   * Removes all attached event listeners from the bot.
+   */
+  cleanup (): void {
+    for (const sub of this.subscriptions) {
+      // @ts-expect-error
+      this.bot.removeListener(sub.eventName, sub.callback)
+    }
+  }
+}

--- a/src/Tool.ts
+++ b/src/Tool.ts
@@ -4,7 +4,6 @@ import { Item } from 'prismarine-item'
 import { retrieveTools, standardToolFilter } from './Inventory'
 import { Vec3 } from 'vec3'
 
-// @ts-expect-error ; nbt has no typescript header
 import * as nbt from 'prismarine-nbt'
 
 export type Callback = (err?: Error) => void
@@ -75,6 +74,7 @@ export class Tool {
   private getDigTime (block: Block, item?: Item): number {
     // @ts-expect-error ; entity effects not in typescript header
     const effects = this.bot.entity.effects
+    // @ts-expect-error
     const enchants = item?.nbt != null ? nbt.simplify(item.nbt).Enchantments : []
 
     // @ts-expect-error ; enchants/effects not in digTime typescript header


### PR DESCRIPTION
The goal is to migrate mineflayer-collectblock to mineflayer@3.6.0. That is dependent on mineflayer-tool being updated.

There is a [related dependency pr](https://github.com/PrismarineJS/mineflayer-tool/pull/27) that uses `latest` for many of the versions. We need to decide what route to take.

TaskQueue and TemporarySubscriber are from mineflayer-collectblock with one modification to fix a syntax issue.
https://github.com/PrismarineJS/mineflayer-collectblock/blob/master/src/TemporarySubscriber.ts
https://github.com/PrismarineJS/mineflayer-collectblock/blob/master/src/TaskQueue.ts
These were originally in mineflayer-utils, but were removed when mineflayer-collectblock removed the dependency. 