### PR TITLE
Allow doing bot.tool without getting an error

### DIFF
--- a/src/Tool.ts
+++ b/src/Tool.ts
@@ -165,3 +165,10 @@ export class Tool {
     }
   }
 }
+
+
+declare module 'mineflayer' {
+	interface Bot {
+		tool: Tool
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,6 @@ export function plugin (bot: Bot): void {
     }
   }, 0)
 
-  // @ts-expect-error
   bot.tool = new Tool(bot)
 }
 


### PR DESCRIPTION
Also, next time mineflayer-pathfinder makes a release you can remove line 8 in index.ts because of https://github.com/PrismarineJS/mineflayer-pathfinder/pull/156